### PR TITLE
Add all props to script tags.

### DIFF
--- a/src/HTMLDocument.jsx
+++ b/src/HTMLDocument.jsx
@@ -36,9 +36,9 @@ class HTMLDocument extends Component {
     );
   }
 
-  renderSourcedScript(src) {
+  renderSourcedScript(props) {
     return (
-      <script key={src} src={src} />
+      <script {...props} />
     );
   }
 
@@ -72,7 +72,7 @@ class HTMLDocument extends Component {
       const scriptProps = typeof props === 'string' ? { src: props } : props;
       const renderedTag = scriptProps.inline ?
         this.renderInlineScript(scriptProps.inline) :
-        this.renderSourcedScript(scriptProps.src);
+        this.renderSourcedScript(scriptProps);
       return renderedTag;
     });
   }


### PR DESCRIPTION
**reviewer**
@xavierelopez 

**summary**
render all given props to script tags. this will allow for users to render more descriptive script tags, like `<script src="script.js" crossorigin="anonymous" />` whereas before that was not possible.