### PR TITLE
Use textContent instead of innerText for client helper.

### DIFF
--- a/dist/client.js
+++ b/dist/client.js
@@ -9,7 +9,7 @@ exports['default'] = getUniversalState;
 var _constants = require('./constants');
 
 var defaultStateParser = function defaultStateParser(script) {
-  return JSON.parse(script.innerText);
+  return JSON.parse(script.textContent);
 };
 
 function getUniversalStateFromScript(script) {

--- a/src/client.js
+++ b/src/client.js
@@ -1,7 +1,7 @@
 import { STATE_SCRIPT_ID, ERRORS } from './constants';
 
 
-const defaultStateParser = script => JSON.parse(script.innerText);
+const defaultStateParser = script => JSON.parse(script.textContent);
 
 export function getUniversalStateFromScript(script, parser = defaultStateParser) {
   if ( !script ) {


### PR DESCRIPTION
Fixes a compatibility issue with Firefox.
