### PR TITLE
Removed deprecated PropTypes

### DIFF
--- a/dist/HTMLDocument.js
+++ b/dist/HTMLDocument.js
@@ -20,6 +20,10 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
 var _reactDomServer = require('react-dom/server');
 
 var _reactDomServer2 = _interopRequireDefault(_reactDomServer);
@@ -165,15 +169,15 @@ var HTMLDocument = (function (_Component) {
 })(_react.Component);
 
 HTMLDocument.propTypes = {
-  childrenContainerId: _react.PropTypes.string,
-  children: _react.PropTypes.node,
-  htmlAttributes: _react.PropTypes.object,
-  favicon: _react.PropTypes.string,
-  metatags: _react.PropTypes.array,
-  scripts: _react.PropTypes.array,
-  stylesheets: _react.PropTypes.array,
-  title: _react.PropTypes.string,
-  universalState: _react.PropTypes.object
+  childrenContainerId: _propTypes2['default'].string,
+  children: _propTypes2['default'].node,
+  htmlAttributes: _propTypes2['default'].object,
+  favicon: _propTypes2['default'].string,
+  metatags: _propTypes2['default'].array,
+  scripts: _propTypes2['default'].array,
+  stylesheets: _propTypes2['default'].array,
+  title: _propTypes2['default'].string,
+  universalState: _propTypes2['default'].object
 };
 
 HTMLDocument.defaultProps = {

--- a/package.json
+++ b/package.json
@@ -47,9 +47,10 @@
     "eslint-config-airbnb": "^0.1.0",
     "eslint-plugin-react": "^3.6.3",
     "mocha": "^2.3.3",
+    "prop-types": "^15.5.8",
     "react": "^15.0.2"
   },
   "dependencies": {
-    "react-dom": "^15.0.2"
+    "react-dom": "^15.5.0"
   }
 }

--- a/src/HTMLDocument.jsx
+++ b/src/HTMLDocument.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom/server';
 
 import { STATE_SCRIPT_ID, ASSET_TYPES } from './constants';

--- a/test/TestApp.jsx
+++ b/test/TestApp.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 
 class TestApp extends Component {

--- a/test/test-script.js
+++ b/test/test-script.js
@@ -1,1 +1,2 @@
+/* eslint-disable */
 var x = 1;


### PR DESCRIPTION
React version 15.5.0 add deprecated warning for React.PropTypes.
More info [on React blog](https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html).