### PR TITLE
Add prop to include scripts inside head tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ const state = getUniversalState(); // { user: "X"}
 | `title` | string | Title for the document. | `''`
 | `metatags`    | array | A list of meta tag attributes. | `[ ]`
 | `scripts` | array | A list of scripts in one of three forms: string paths `'mysite.com/script.js'`, script src objects `{ src: 'mysite.com/script.js' }` or inline scripts `{ inline: 'var x = 1;' }` | `[ ]`
+| `headScripts` | array | A list of scripts inside the head tag. it follows the same format as `scripts`
 | `stylesheets` | array | A list of stylesheet in one of three forms: string paths `'mysite.com/styles.css'`, style href objects `{ href: 'mysite.com/styles.css' }` or inline styles `{ inline: 'body { color: '#333' }' }` | `[ ]`
 | `universalState` | object | Contains current server state that will be rendered into a script tag of type `application/json` on the page. Helpful for re-mounting with props on the client in universal apps. When not using it, children will be rendered statically. | `null`
 | `childrenContainerId`           | string | The id for the dom element that contains the children nodes. | `'app'`

--- a/dist/HTMLDocument.js
+++ b/dist/HTMLDocument.js
@@ -112,15 +112,23 @@ var HTMLDocument = (function (_Component) {
     }
   }, {
     key: 'renderScripts',
-    value: function renderScripts() {
+    value: function renderScripts(scripts) {
       var _this2 = this;
-
-      var scripts = this.props.scripts;
 
       return scripts.map(function (props) {
         var scriptProps = typeof props === 'string' ? { src: props } : props;
         return _this2.renderAsset(_constants.ASSET_TYPES.SCRIPT, scriptProps);
       });
+    }
+  }, {
+    key: 'renderBodyScripts',
+    value: function renderBodyScripts() {
+      return this.renderScripts(this.props.scripts);
+    }
+  }, {
+    key: 'renderHeadScripts',
+    value: function renderHeadScripts() {
+      return this.renderScripts(this.props.headScripts);
     }
   }, {
     key: 'renderUniversalStateScript',
@@ -148,14 +156,15 @@ var HTMLDocument = (function (_Component) {
           ),
           this.renderMetatags(),
           this.renderFavicon(),
-          this.renderStylesheets()
+          this.renderStylesheets(),
+          this.renderHeadScripts()
         ),
         _react2['default'].createElement(
           'body',
           null,
           this.renderChildren(),
           this.renderUniversalStateScript(),
-          this.renderScripts()
+          this.renderBodyScripts()
         )
       );
     }
@@ -171,6 +180,7 @@ HTMLDocument.propTypes = {
   favicon: _react.PropTypes.string,
   metatags: _react.PropTypes.array,
   scripts: _react.PropTypes.array,
+  headScripts: _react.PropTypes.array,
   stylesheets: _react.PropTypes.array,
   title: _react.PropTypes.string,
   universalState: _react.PropTypes.object
@@ -182,6 +192,7 @@ HTMLDocument.defaultProps = {
   favicon: '',
   metatags: [],
   scripts: [],
+  headScripts: [],
   stylesheets: [],
   title: '',
   universalState: null

--- a/example-usage-server.js
+++ b/example-usage-server.js
@@ -19,6 +19,17 @@ function render(req, res) {
         inline: 'var x = 2;'
       }
     ],
+    headScripts: [
+      {
+        src: '/dist/my-head-script.js',
+      },
+      {
+        file: path.join(__dirname, './test/test-script.js')
+      },
+      {
+        inline: 'var x = 3;'
+      }
+    ],
     stylesheets: [
       {
         href: 'https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css'

--- a/src/HTMLDocument.jsx
+++ b/src/HTMLDocument.jsx
@@ -64,12 +64,19 @@ class HTMLDocument extends Component {
     });
   }
 
-  renderScripts() {
-    const { scripts } = this.props;
+  renderScripts(scripts) {
     return scripts.map(props => {
       const scriptProps = typeof props === 'string' ? { src: props } : props;
       return this.renderAsset(ASSET_TYPES.SCRIPT, scriptProps);
     });
+  }
+
+  renderBodyScripts() {
+    return this.renderScripts(this.props.scripts);
+  }
+
+  renderHeadScripts() {
+    return this.renderScripts(this.props.headScripts);
   }
 
   renderUniversalStateScript() {
@@ -88,11 +95,12 @@ class HTMLDocument extends Component {
           {this.renderMetatags()}
           {this.renderFavicon()}
           {this.renderStylesheets()}
+          {this.renderHeadScripts()}
         </head>
         <body>
           {this.renderChildren()}
           {this.renderUniversalStateScript()}
-          {this.renderScripts()}
+          {this.renderBodyScripts()}
         </body>
       </html>
     );
@@ -106,6 +114,7 @@ HTMLDocument.propTypes = {
   favicon: PropTypes.string,
   metatags: PropTypes.array,
   scripts: PropTypes.array,
+  headScripts: PropTypes.array,
   stylesheets: PropTypes.array,
   title: PropTypes.string,
   universalState: PropTypes.object
@@ -117,6 +126,7 @@ HTMLDocument.defaultProps = {
   favicon: '',
   metatags: [],
   scripts: [],
+  headScripts: [],
   stylesheets: [],
   title: '',
   universalState: null

--- a/test/HTMLDocument.spec.js
+++ b/test/HTMLDocument.spec.js
@@ -188,6 +188,18 @@ describe('HTMLDocument', () => {
       expect($scripts.length).to.equal(1);
       expect($scripts.html()).to.equal(scriptContents);
     });
+
+    it('should render scripts inside head tag', () => {
+      const props = {
+        headScripts: [
+          { inline: 'window.myApp = true;' }
+        ],
+      };
+      const qs = renderAndGetQuerySelector(props);
+      const $scripts = qs('head script').not(`script#${STATE_SCRIPT_ID}`);
+      expect($scripts.length).to.equal(1);
+      expect($scripts.html()).to.equal(props.headScripts[0].inline);
+    });
   });
 
   describe('Children', () => {


### PR DESCRIPTION
This Pull Request is to add a option to the component to render scripts inside the head Tag.
`<HTMLDocument headScripts={{ src: 'my-script-inside-head-tag.js' }}>
      <h1>Hello World</h1>
    </HTMLDocument>`